### PR TITLE
fix: add missing Dataplex dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "google-cloud-storage",
     "google-cloud-bigquery",
     "google-cloud-bigquery-migration",
+    "google-cloud-dataplex",
     "google-cloud-videointelligence",
     "fpdf",
     "google-genai",


### PR DESCRIPTION
Fixes #114.

This adds google-cloud-dataplex to the project dependencies because the ADK BigQuery/Dataform tool path imports google.cloud.dataplex_v1, but the package was not declared in pyproject.toml.

Verification:
- Parsed pyproject.toml with Python 3.12 and confirmed google-cloud-dataplex appears exactly once in [project].dependencies.
- In a clean Python 3.12 virtual environment, installed google-cloud-dataplex and confirmed rom google.cloud import dataplex_v1 succeeds.

Note: I intentionally left uv.lock unchanged. Running uv lock locally without Google internal Artifact Registry credentials rewrites the lockfile with large unrelated registry/project metadata changes; regenerating the lockfile cleanly likely needs the repository's configured package index credentials.